### PR TITLE
Remove unused torchvision dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ keywords = [
 ]
 dependencies = [
     "torch==2.8.0",
-    "torchvision==0.23.0",
     "acvl-utils>=0.2.3,<0.3",  # 0.3 may bring breaking changes. Careful!
     "dynamic-network-architectures>=0.4.1,<0.5",
     "tqdm",


### PR DESCRIPTION
Removed unused torchvision dependency. Avoid potential conflicts when pip-installing nnlandmark in projects that depend on a different version